### PR TITLE
Allow openssl up to 4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     veryfi (2.0.0)
       base64 (~> 0.1)
       faraday (>= 1.7, < 3.0)
-      openssl (>= 2.2, < 3.1)
+      openssl (>= 2.2, < 4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -40,7 +40,7 @@ GEM
       concurrent-ruby (~> 1.0)
     method_source (1.1.0)
     minitest (5.23.1)
-    openssl (3.0.2)
+    openssl (4.0.0)
     parallel (1.24.0)
     parser (3.3.2.0)
       ast (~> 2.4.1)
@@ -53,8 +53,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.2)
-    rexml (3.2.9)
-      strscan
+    rexml (3.4.4)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -94,8 +93,7 @@ GEM
     simplecov-badge (2.0.2)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    strscan (3.1.0)
-    thor (1.3.1)
+    thor (1.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
@@ -118,7 +116,7 @@ DEPENDENCIES
   bundler-audit (~> 0.9)
   pry (~> 0.14)
   rake (~> 13.0)
-  rexml (~> 3.2.7)
+  rexml (~> 3.4.4)
   rspec (~> 3.9)
   rspec-its (~> 1.3)
   rubocop (~> 0.82)

--- a/veryfi.gemspec
+++ b/veryfi.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
 
   spec.add_dependency "base64", "~> 0.1"
-  spec.add_dependency "openssl", ">= 2.2", "< 3.1"
+  spec.add_dependency "openssl", ">= 2.2", "< 4.1"
 
   spec.add_dependency "faraday", ">= 1.7", "< 3.0"
 
@@ -82,6 +82,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov-badge", "~> 2.0"
   spec.add_development_dependency "vcr", "~> 6.0"
   spec.add_development_dependency "webmock", "~> 3.14"
-  spec.add_development_dependency "rexml", "~> 3.2.7"
+  spec.add_development_dependency "rexml", "~> 3.4.4"
   spec.add_development_dependency "activesupport", "~> 6.0"
 end


### PR DESCRIPTION
While trying to install this gem in a Ruby 3.4.8 Alpine-based Docker image, the installation fails due to an issue with the latest allowed version of OpenSSL (3.0.3).

At the moment, the gem restricts the `openssl` dependency to versions < 3.1. However, the gem only relies on HMAC functionality, which remains unchanged and compatible in OpenSSL 4.0 as well.

This pull request addresses the issue by relaxing the OpenSSL version constraint to allow versions < 4.1. Also it's updating `rexml` and `thor` dependencies so that the `bin/ci` command runs the test suite correctly.

Below is the output of `bin/ci` after the changes made:
```
Inspecting 18 files
..................

18 files inspected, no offenses detected
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Already up to date.
Updated ruby-advisory-db
ruby-advisory-db:
  advisories:	1035 advisories
  last updated:	2025-12-16 11:19:05 -0800
  commit:	c5a81fbbb46f6a0a4d2f0aedda409305c76da5a4
No vulnerabilities found
/Users/valeronm/projects/veryfi-ruby/spec/spec_helper.rb:21:in `block in <top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.
......................

Finished in 0.16265 seconds (files took 0.3001 seconds to load)
22 examples, 0 failures

Coverage report generated for RSpec to /Users/valeronm/projects/veryfi-ruby/coverage. 351 / 351 LOC (100.0%) covered.
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"

convert: missing required argument  @ error/deprecate.c/ConvertImageCommand/571.
ImageMagick doesn't appear to be installed.
Simplecov-Badge was unable to generate a badge for RSpec.
```