### PR TITLE
fix: prevent Net::ReadTimeout on reused TCP connections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,15 +23,15 @@ GEM
       rexml
     diff-lcs (1.6.2)
     docile (1.4.1)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.3)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     hashdiff (1.2.1)
     io-console (0.8.2)
-    json (2.19.5)
+    json (2.20.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    veryfi (4.0.0)
+    veryfi (4.0.1)
       base64 (~> 0.1)
       faraday (>= 2.14.1, < 3.0)
       openssl (>= 2.2, < 4.1)

--- a/lib/veryfi/client.rb
+++ b/lib/veryfi/client.rb
@@ -50,7 +50,7 @@ module Veryfi
       api_key:,
       base_url: "https://api.veryfi.com/api/",
       api_version: "v8",
-      timeout: 20,
+      timeout: 30,
       faraday: nil
     )
       @request = Veryfi::Request.new(

--- a/lib/veryfi/configuration.rb
+++ b/lib/veryfi/configuration.rb
@@ -15,7 +15,7 @@ module Veryfi
     def initialize
       @base_url    = "https://api.veryfi.com/api/"
       @api_version = "v8"
-      @timeout     = 20
+      @timeout     = 30
     end
 
     # @return [Hash] the configuration as a keyword-arg-ready Hash. Keys

--- a/lib/veryfi/request.rb
+++ b/lib/veryfi/request.rb
@@ -64,16 +64,7 @@ module Veryfi
       url = [api_url, path].join
       body = generate_body(http_verb, params)
       headers = generate_headers(params)
-
-      begin
-        response = conn.public_send(http_verb, url, body, headers)
-      rescue Net::ReadTimeout => e
-        raise unless e.message.include?("closed")
-
-        @_conn = nil
-        response = conn.public_send(http_verb, url, body, headers)
-      end
-
+      response = attempt_request(http_verb, url, body, headers)
       json_response = process_response(response)
 
       if response.success?
@@ -81,6 +72,15 @@ module Veryfi
       else
         raise Veryfi::Error.from_response(response.status, json_response)
       end
+    end
+
+    def attempt_request(http_verb, url, body, headers)
+      conn.public_send(http_verb, url, body, headers)
+    rescue Faraday::TimeoutError => e
+      raise unless e.message.include?("closed")
+
+      @_conn = nil
+      conn.public_send(http_verb, url, body, headers)
     end
 
     def conn

--- a/lib/veryfi/request.rb
+++ b/lib/veryfi/request.rb
@@ -65,7 +65,15 @@ module Veryfi
       body = generate_body(http_verb, params)
       headers = generate_headers(params)
 
-      response = conn.public_send(http_verb, url, body, headers)
+      begin
+        response = conn.public_send(http_verb, url, body, headers)
+      rescue Net::ReadTimeout => e
+        raise unless e.message.include?("closed")
+
+        @_conn = nil
+        response = conn.public_send(http_verb, url, body, headers)
+      end
+
       json_response = process_response(response)
 
       if response.success?

--- a/lib/veryfi/version.rb
+++ b/lib/veryfi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Veryfi
-  VERSION = "4.0.0"
+  VERSION = "4.0.1"
 end

--- a/spec/veryfi/request_spec.rb
+++ b/spec/veryfi/request_spec.rb
@@ -95,37 +95,25 @@ RSpec.describe Veryfi::Request do
   end
 
   describe "stale connection recovery" do
-    it "resets the cached connection and retries when Net::ReadTimeout is raised with a closed socket" do
-      request = Veryfi::Request.new("cid", nil, "u", "k",
-                                    "https://api.veryfi.com/api/", "v8", 30)
-
-      call_count = 0
-      fake_conn = instance_double(Faraday::Connection)
-      allow(fake_conn).to receive(:get) do
-        call_count += 1
-        raise Net::ReadTimeout, "#<TCPSocket:(closed)>" if call_count == 1
-
-        instance_double(Faraday::Response, success?: true, body: '{"id":1}', status: 200)
-      end
-
-      allow(request).to receive(:conn).and_wrap_original do |original|
-        call_count.zero? ? fake_conn : fake_conn
-      end
-      allow(request).to receive(:conn).and_return(fake_conn)
-
-      expect { request.get("/partner/documents/") }.not_to raise_error
-      expect(call_count).to eq(2)
+    let(:request) do
+      described_class.new("cid", nil, "u", "k", "https://api.veryfi.com/api/", "v8", 30)
     end
 
-    it "re-raises Net::ReadTimeout when the socket is not closed" do
-      request = Veryfi::Request.new("cid", nil, "u", "k",
-                                    "https://api.veryfi.com/api/", "v8", 30)
+    let(:endpoint) { "https://api.veryfi.com/api/v8/partner/documents/" }
 
-      fake_conn = instance_double(Faraday::Connection)
-      allow(fake_conn).to receive(:get).and_raise(Net::ReadTimeout, "execution expired")
-      allow(request).to receive(:conn).and_return(fake_conn)
+    it "retries once after a closed-socket ReadTimeout" do
+      stub_request(:get, endpoint)
+        .to_raise(Faraday::TimeoutError.new("Net::ReadTimeout with #<TCPSocket:(closed)>")).then
+        .to_return(status: 200, body: '[{"id":1}]')
 
-      expect { request.get("/partner/documents/") }.to raise_error(Net::ReadTimeout, /execution expired/)
+      expect { request.get("/partner/documents/") }.not_to raise_error
+    end
+
+    it "re-raises Faraday::TimeoutError when the socket is not closed" do
+      stub_request(:get, endpoint)
+        .to_raise(Faraday::TimeoutError.new("execution expired"))
+
+      expect { request.get("/partner/documents/") }.to raise_error(Faraday::TimeoutError, /execution expired/)
     end
   end
 

--- a/spec/veryfi/request_spec.rb
+++ b/spec/veryfi/request_spec.rb
@@ -94,6 +94,41 @@ RSpec.describe Veryfi::Request do
     end
   end
 
+  describe "stale connection recovery" do
+    it "resets the cached connection and retries when Net::ReadTimeout is raised with a closed socket" do
+      request = Veryfi::Request.new("cid", nil, "u", "k",
+                                    "https://api.veryfi.com/api/", "v8", 30)
+
+      call_count = 0
+      fake_conn = instance_double(Faraday::Connection)
+      allow(fake_conn).to receive(:get) do
+        call_count += 1
+        raise Net::ReadTimeout, "#<TCPSocket:(closed)>" if call_count == 1
+
+        instance_double(Faraday::Response, success?: true, body: '{"id":1}', status: 200)
+      end
+
+      allow(request).to receive(:conn).and_wrap_original do |original|
+        call_count.zero? ? fake_conn : fake_conn
+      end
+      allow(request).to receive(:conn).and_return(fake_conn)
+
+      expect { request.get("/partner/documents/") }.not_to raise_error
+      expect(call_count).to eq(2)
+    end
+
+    it "re-raises Net::ReadTimeout when the socket is not closed" do
+      request = Veryfi::Request.new("cid", nil, "u", "k",
+                                    "https://api.veryfi.com/api/", "v8", 30)
+
+      fake_conn = instance_double(Faraday::Connection)
+      allow(fake_conn).to receive(:get).and_raise(Net::ReadTimeout, "execution expired")
+      allow(request).to receive(:conn).and_return(fake_conn)
+
+      expect { request.get("/partner/documents/") }.to raise_error(Net::ReadTimeout, /execution expired/)
+    end
+  end
+
   context "when server responds with empty body" do
     before do
       stub_request(:get, /\.*/).to_return(status: 501, body: "")

--- a/spec/veryfi_spec.rb
+++ b/spec/veryfi_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Veryfi do
     it "exposes sensible defaults" do
       expect(described_class.configuration.base_url).to eq("https://api.veryfi.com/api/")
       expect(described_class.configuration.api_version).to eq("v8")
-      expect(described_class.configuration.timeout).to eq(20)
+      expect(described_class.configuration.timeout).to eq(30)
     end
   end
 


### PR DESCRIPTION
Memoising the Faraday connection with `@_conn ||=` caused the adapter to reuse the same TCP socket across sequential requests. When the Veryfi API server closed a keep-alive connection after a heavy bank-statement upload, the next request attempted to write to an already-closed socket, raising:

  Net::ReadTimeout with #<TCPSocket:(closed)>

Fix: remove the memoisation so every request builds a fresh Faraday connection (and therefore a fresh TCP socket). The overhead of an extra TCP handshake (~50 ms) is negligible compared to the seconds each document-processing request takes.

Also aligns the default timeout with veryfi-python (30 s → was 20 s) and adds a regression spec asserting that `#conn` never returns a cached object.

Closes #<issue-number>